### PR TITLE
secretstorage 3.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,32 +1,32 @@
-{% set version = "3.3.1" %}
+{% set name = "secretstorage" %}
+{% set version = "3.4.0" %}
 
 package:
-  name: secretstorage
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/S/SecretStorage/SecretStorage-{{ version }}.tar.gz
-  sha256: fd666c51a6bf200643495a04abb261f83229dcb6fd8472ec393df7ffc8b6f195
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c46e216d6815aff8a8a18706a2fbfd8d53fcbb0dce99301881687a1b0289ef7c
 
 build:
-  number: 1
-  skip: true  # [win or py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  number: 0
+  skip: true  # [win or py<310]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
 
 requirements:
   host:
-    - python
     - pip
-    - setuptools
-    - wheel
-    # needed to get pinning
-    - dbus 1.*
+    - python
+    - dbus {{ dbus }}
+    - setuptools >=77.0
   run:
     - python
     - jeepney >=0.6
     - cryptography >=2.0
-    - dbus >=1.13.18,<2.0a0
+    - dbus # bounds set through run exports. 
 
+# Didn't run upstream tests due to inability to run dbus services
 test:
   imports:
     - secretstorage
@@ -34,7 +34,6 @@ test:
     - pip
   commands:
     - pip check
-
 
 about:
   home: https://github.com/mitya57/secretstorage
@@ -52,7 +51,7 @@ about:
     SecretStorage supports most of the functions provided by Secret Service, 
     including creating and deleting items and collections, editing items, locking 
     and unlocking collections (asynchronous unlocking is also supported).
-  doc_url: https://secretstorage.readthedocs.io/en/latest/
+  doc_url: https://secretstorage.readthedocs.io
   dev_url: https://github.com/mitya57/secretstorage
 
 extra:


### PR DESCRIPTION
secretstorage 3.4.0 

**Destination channel:** Defaults

### Links

- [PKG-9421]
- dev_url:        https://github.com/mitya57/secretstorage/tree/3.4.0
- conda_forge:    https://github.com/conda-forge/secretstorage-feedstock
- pypi:           https://pypi.org/project/secretstorage/3.4.0
- pypi inspector: https://inspector.pypi.io/project/secretstorage/3.4.0

### Explanation of changes:

- new version number


[PKG-9421]: https://anaconda.atlassian.net/browse/PKG-9421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ